### PR TITLE
Add a meta file to describe the role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,12 @@
+---
+galaxy_info:
+  author: Jan Pavlíček
+  description: Install and configure openldap
+  company: CESNET
+  license: MIT
+  min_ansible_version: 2.4
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+      galaxy_tags: [ldap, openldap, system]


### PR DESCRIPTION
Hello,

We can't install your role with ansible-galaxy because meta file is missing. What do you think about adding this meta config ?

Best regards,
J.